### PR TITLE
Initial static application infrastructure

### DIFF
--- a/ops/aws/terraform/deployment/static/backend.tf
+++ b/ops/aws/terraform/deployment/static/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    /*
+    Copy backend.tfvars.sample to backend.tfvars, populate
+    with the appropriate values and initialize the backend with:
+    terraform init -backend-config=backend.tfvars
+    */
+  }
+}

--- a/ops/aws/terraform/deployment/static/backend.tfvars.sample
+++ b/ops/aws/terraform/deployment/static/backend.tfvars.sample
@@ -1,0 +1,6 @@
+bucket         = "#STATE_BUCKET#"
+key            = "#APP#/#ENV#/deployment.tfstate"
+region         = "#REGION#"
+dynamodb_table = "#DYNAMO_TABLE#"
+encrypt        = 1
+# TODO: kms_key_id

--- a/ops/aws/terraform/deployment/static/main.tf
+++ b/ops/aws/terraform/deployment/static/main.tf
@@ -1,0 +1,115 @@
+provider "aws" {
+  alias  = "${var.region}"
+  region = "${var.region}"
+}
+
+data "template_file" "blue_bucket_policy" {
+  template = "${file("${path.module}/website_bucket_policy.json")}"
+
+  vars {
+    bucket = "${var.application_name}-${var.environment}-blue-deploy-bucket"
+  }
+}
+
+data "template_file" "green_bucket_policy" {
+  template = "${file("${path.module}/website_bucket_policy.json")}"
+
+  vars {
+    bucket = "${var.application_name}-${var.environment}-green-deploy-bucket"
+  }
+}
+
+resource "aws_s3_bucket" "blue_bucket" {
+  provider = "aws.${var.region}"
+  bucket   = "${var.application_name}-${var.environment}-blue-deploy-bucket"
+  policy   = "${data.template_file.blue_bucket_policy.rendered}"
+
+  website {
+    index_document = "index.html"
+    error_document = "404.html"
+  }
+
+  tags = "${merge("${var.tags}",map("Name", "${var.application_name}-${var.environment}-${var.domain}", "env", "${var.environment}", "app", "${var.application_name}"))}"
+
+}
+
+resource "aws_s3_bucket" "green_bucket" {
+  provider = "aws.${var.region}"
+  bucket   = "${var.application_name}-${var.environment}-green-deploy-bucket"
+  policy   = "${data.template_file.green_bucket_policy.rendered}"
+
+  website {
+    index_document = "index.html"
+    error_document = "404.html"
+  }
+
+  tags = "${merge("${var.tags}",map("Name", "${var.application_name}-${var.environment}-${var.domain}", "env", "${var.environment}", "app", "${var.application_name}"))}"
+
+}
+
+resource "aws_cloudfront_distribution" "website_cdn" {
+  enabled      = true
+  price_class  = "PriceClass_200"
+  http_version = "http1.1"
+
+  "origin" {
+    origin_id   = "origin-bucket-${aws_s3_bucket.blue_bucket.id}"
+    domain_name = "${aws_s3_bucket.blue_bucket.website_endpoint}"
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1"]
+    }
+
+  }
+
+  default_root_object = "index.html"
+
+  custom_error_response {
+    error_code            = "404"
+    error_caching_min_ttl = "360"
+    response_code         = "200"
+    response_page_path    = "${var.not-found-response-path}"
+  }
+
+  "default_cache_behavior" {
+    allowed_methods = ["GET", "HEAD", "DELETE", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD"]
+
+    "forwarded_values" {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    trusted_signers = ["${var.trusted_signers}"]
+
+    min_ttl          = "0"
+    default_ttl      = "300"                                              //3600
+    max_ttl          = "1200"                                             //86400
+    target_origin_id = "origin-bucket-${aws_s3_bucket.blue_bucket.id}"
+
+    // This redirects any HTTP request to HTTPS. Security first!
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+  }
+
+  "restrictions" {
+    "geo_restriction" {
+      restriction_type = "none"
+    }
+  }
+
+  "viewer_certificate" {
+    cloudfront_default_certificate = true
+  }
+
+  aliases = ["${var.domain}"]
+
+  tags = "${merge("${var.tags}",map("Name", "${var.application_name}-${var.environment}-${var.domain}", "env", "${var.environment}", "app", "${var.application_name}"))}"
+
+}

--- a/ops/aws/terraform/deployment/static/output.tf
+++ b/ops/aws/terraform/deployment/static/output.tf
@@ -1,0 +1,15 @@
+output "blue_website_bucket_id" {
+  value = "${aws_s3_bucket.blue_bucket.id}"
+}
+
+output "green_website_bucket_id" {
+  value = "${aws_s3_bucket.green_bucket.id}"
+}
+
+output "blue_website_bucket_arn" {
+  value = "${aws_s3_bucket.blue_bucket.arn}"
+}
+
+output "green_website_bucket_arn" {
+  value = "${aws_s3_bucket.green_bucket.arn}"
+}

--- a/ops/aws/terraform/deployment/static/variables.tf
+++ b/ops/aws/terraform/deployment/static/variables.tf
@@ -1,0 +1,32 @@
+variable "environment" {
+  type = "string"
+}
+
+variable "application_name" {
+  type = "string"
+}
+
+variable "region" {
+  type    = "string"
+  default = "us-east-1"
+}
+
+variable "not-found-response-path" {
+  default = "/404.html"
+}
+
+variable "trusted_signers" {
+  type = "list"
+  default = []
+}
+
+variable "domain" {
+  type    = "string"
+  default = "soapbox.hosting"
+}
+
+variable "tags" {
+  type        = "map"
+  description = "Optional Tags"
+  default     = {}
+}

--- a/ops/aws/terraform/deployment/static/variables.tf
+++ b/ops/aws/terraform/deployment/static/variables.tf
@@ -20,7 +20,7 @@ variable "trusted_signers" {
   default = []
 }
 
-variable "domain" {
+variable "platform_domain" {
   type    = "string"
   default = "soapbox.hosting"
 }

--- a/ops/aws/terraform/deployment/static/website_bucket_policy.json
+++ b/ops/aws/terraform/deployment/static/website_bucket_policy.json
@@ -1,0 +1,15 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Resource": "arn:aws:s3:::${bucket}/*",
+            "Sid": "PublicReadAccess"
+        }
+    ]
+}


### PR DESCRIPTION
Terraform templates for https://github.com/adhocteam/soapbox/issues/140

This PR contains the terraform templates to launch the following static application infrastructure:
* Blue s3 bucket
* Green s3 bucket
* Cloudfront distribution
* Route53 record

To launch from local environment:
```
$ cd ops/aws/terraform/deployment/static
$ terraform apply -var application_name=static-app -var environment=test
```

to do (tracked in https://github.com/adhocteam/soapbox/issues/138):
* Assets are built for commit sha and uploaded to s3
* Update CloudFront distribution for blue environment by removing S3 bucket CNAME from Alternative Domain Names
* Update CloudFront distribution for green environment by adding S3 bucket CNAME to Alternative Domain Names
* Update Route53 A Alias record with CloudFront distribution Domain Name from green environment