### PR TITLE
Fixes user/repo name parsing from github URL.

### DIFF
--- a/web/app/controllers/deployments_controller.rb
+++ b/web/app/controllers/deployments_controller.rb
@@ -73,7 +73,7 @@ class DeploymentsController < ApplicationController
   end
 
   def find_commits
-    github_repo = @app.github_repo_url.gsub(%r{https://.*@github.com/}, '').gsub(/\.git$/, '')
+    github_repo = @app.github_repo_url.split('github.com/').last.gsub(/\.git$/, '')
     @commits = octokit.commits(github_repo, 'master', per_page: 1000).map do |c|
       ["#{c.commit.message} (#{c.sha})", c.sha]
     end


### PR DESCRIPTION
When deploying [example-web-app](https://github.com/adhocteam/example-web-app), I got an `Octokit::InvalidRepository` error.

Looks like the regex was not matching (I think due to the `@`). Thought this was little more flexible if we wanted to handle SSH and HTTPS URLs.